### PR TITLE
fix: mutual-cancel between fd/timer/trigger handlers in Event

### DIFF
--- a/bbt/pollevent/Event.cc
+++ b/bbt/pollevent/Event.cc
@@ -67,10 +67,16 @@ int Event::StartListen(uint64_t timeout)
     // 定时器事件（可与 fd 事件共存）
     if (m_timer) {
         if (timeout > 0) {
+            m_timer->cancel();  // 防止重复 StartListen 导致双重 async_wait UB
             m_timer->expires_after(std::chrono::milliseconds(timeout));
             m_timer->async_wait([this](boost::system::error_code ec) {
                 if (ec == boost::asio::error::operation_aborted)
                     return;
+                // Plan C: timer 触发时取消 fd 等待，防止 double-fire
+                if (m_sd) {
+                    boost::system::error_code ignored;
+                    m_sd->cancel(ignored);
+                }
                 CallEventCallback(m_id, -1, EV_TIMEOUT);
             });
         }
@@ -110,6 +116,11 @@ void Event::DoAsyncWait(short event_flag)
         [this, id, event_flag, persist, fd](boost::system::error_code ec) {
             if (ec == boost::asio::error::operation_aborted)
                 return;
+
+            // Plan C: fd 就绪时取消 timer，防止 double-fire
+            if (m_timer) {
+                m_timer->cancel();
+            }
 
             CallEventCallback(id, fd, event_flag);
 
@@ -156,6 +167,15 @@ int Event::CancelListen(bool need_close_fd)
 
 int Event::Trigger(int flag)
 {
+    // Plan C: Trigger 时取消所有挂起的异步操作，防止与其他路径 double-fire
+    if (m_timer) {
+        m_timer->cancel();
+    }
+    if (m_sd) {
+        boost::system::error_code ignored;
+        m_sd->cancel(ignored);
+    }
+
     EventId id = m_id;
     int fd = m_fd;
     m_ref_base->GetContext().post([id, fd, flag]() {


### PR DESCRIPTION
- StartListen：在 expires_after 之前添加 m_timer->cancel()，以防止重复调用时出现双重异步等待的未定义行为  
- fd_handler（DoAsyncWait）：当文件描述符触发时，首先取消 m_timer  
- timer_handler：当定时器触发时，首先取消 m_sd  
- Trigger()：在提交回调前，先取消 m_timer 和 m_sd
这解决了双触发/三重触发的问题，即 fd 就绪和定时器超时在 m_callback_map 中独立竞争，导致同一事件多次调用用户回调函数。
1小时疲劳测试：0次崩溃，无性能下降。