### PR TITLE
fix(pollevent): LOOP_NONBLOCK fallback to run_one() causes deadlock

### DIFF
--- a/bbt/pollevent/EventLoop.cc
+++ b/bbt/pollevent/EventLoop.cc
@@ -34,30 +34,25 @@ int EventLoop::StartLoop(int opt)
 
     switch (opt) {
     case EventLoopOpt::LOOP_NONBLOCK: {
-        // 先批量派发已就绪 handler（不阻塞）
+        // 非阻塞：仅处置已就绪事件，无就绪立即返回
         ctx.restart();
         dispatched = static_cast<int>(ctx.poll());
-        if (dispatched > 0)
-            return 0;
-        // 无就绪事件才驱动 reactor（阻塞直到一个事件就绪）
-        ctx.restart();
-        dispatched = static_cast<int>(ctx.run_one());
         return (dispatched > 0) ? 0 : 1;
     }
 
     case EventLoopOpt::LOOP_ONCE:
-        // run_one: 阻塞直到一个 handler 完成（包含 reactor 轮询）
+        // 阻塞：等待一个事件就绪并处置后返回
         dispatched = static_cast<int>(ctx.run_one());
         return (dispatched > 0) ? 0 : 1;
 
     case EventLoopOpt::LOOP_NO_EXIT_ON_EMPTY:
+        // 阻塞：无就绪事件时不退出，继续等待
         ctx.restart();
         dispatched = static_cast<int>(ctx.run_one());
         return (dispatched > 0) ? 0 : 1;
 
     default: {
-        // LOOP_NORMAL: 兼容 libevent EVLOOP_NORMAL
-        // run() 有持久事件时永不返回 → 用 run_one()
+        // LOOP_NORMAL：阻塞，处置一个就绪事件后返回
         dispatched = static_cast<int>(ctx.run_one());
         return (dispatched > 0) ? 0 : 1;
     }

--- a/bbt/pollevent/detail/Define.hpp
+++ b/bbt/pollevent/detail/Define.hpp
@@ -28,13 +28,19 @@ enum EventOpt : short
     FINALIZE                = 0x40,
 };
 
-/* ── 事件循环选项 ── */
+/* ── 事件循环选项 ──
+ *
+ * LOOP_NORMAL:           阻塞，处置一个就绪事件后返回
+ * LOOP_ONCE:             阻塞，等待一个事件就绪并处置后返回
+ * LOOP_NONBLOCK:         非阻塞，仅处置已就绪事件，无就绪立即返回
+ * LOOP_NO_EXIT_ON_EMPTY: 阻塞，无就绪事件时不退出，继续等待
+ */
 enum EventLoopOpt
 {
     LOOP_NORMAL             = 0,
-    LOOP_ONCE               = 0x01,   /* EVLOOP_ONCE */
-    LOOP_NONBLOCK           = 0x02,   /* EVLOOP_NONBLOCK */
-    LOOP_NO_EXIT_ON_EMPTY   = 0x04,   /* EVLOOP_NO_EXIT_ON_EMPTY */
+    LOOP_ONCE               = 0x01,
+    LOOP_NONBLOCK           = 0x02,
+    LOOP_NO_EXIT_ON_EMPTY   = 0x04,
 };
 
 /* ── 线程状态 ── */

--- a/unit_test/pollevent/Test_eventloop.cc
+++ b/unit_test/pollevent/Test_eventloop.cc
@@ -300,6 +300,25 @@ BOOST_AUTO_TEST_CASE(t_timeout_minimal_fires_quickly)
     BOOST_CHECK(fired.load());
 }
 
+BOOST_AUTO_TEST_CASE(t_loop_nonblock_returns_immediately_with_pending_timer)
+{
+    // 回归测试：LOOP_NONBLOCK 不应阻塞等待未就绪的 timer。
+    // run_one() 底层走 epoll_wait，在有 pending timer 时会阻塞，
+    // 导致 scheduler 线程卡死 → 全系统死锁。
+    auto loop = std::make_shared<EventLoop>();
+    auto ev = loop->CreateEvent(-1, EventOpt::TIMEOUT,
+        [](int, short, EventId) {});
+    ev->StartListen(10000); // 10s 后才到期
+
+    auto t0 = std::chrono::steady_clock::now();
+    int ret = loop->StartLoop(EventLoopOpt::LOOP_NONBLOCK);
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+
+    BOOST_CHECK(ret == 0 || ret == 1);
+    BOOST_CHECK(elapsed_ms < 100); // 不应阻塞超过 100ms
+}
+
 BOOST_AUTO_TEST_CASE(t_get_timeout_ms_default_minus_one)
 {
     auto loop = std::make_shared<EventLoop>();


### PR DESCRIPTION
## Summary

修复 `EventLoop::StartLoop(LOOP_NONBLOCK)` 在 ASIO 迁移后引入的死锁。

## Root Cause

`LOOP_NONBLOCK` 在 `poll()` 无就绪事件时 fallback 到 `run_one()`：

```cpp
case LOOP_NONBLOCK:
    dispatched = ctx.poll();        // 非阻塞
    if (dispatched > 0) return 0;
    dispatched = ctx.run_one();     // ← 阻塞！epoll_wait
```

`run_one()` 底层走 `epoll_wait`，当 `io_context` 没有活跃 handler 时**永久阻塞**。触发场景：

1. 所有协程进入 mutex/cond/chan 等自定义事件等待
2. `io_context` 的 timer 全部过期，没有新的 handler
3. `poll()` 返回 0 → `run_one()` 阻塞 → scheduler 线程卡死
4. scheduler 不再调用 `_OnUpdate` → 无人 dispatch 事件 → 全系统死锁

## Libevent 对比

| | libevent `EVLOOP_NONBLOCK` | ASIO `run_one()` |
|---|---|---|
| 有就绪事件 | 派发后返回 | 派发后返回 |
| 无就绪事件 | **立即返回** | **阻塞等待** |

迁移时把 `run_one()` 当 fallback 用，破坏了 NONBLOCK 语义。

## Fix

去掉 `run_one()` fallback，只走 `poll()`：

```cpp
case LOOP_NONBLOCK:
    ctx.restart();
    dispatched = static_cast<int>(ctx.poll());
    return (dispatched > 0) ? 0 : 1;
```

scheduler 自身有 `sleep_until(1ms)` 控制重试频率，不需要 event loop 内部阻塞。

## Verification

- 单元测试：`LOOP_NONBLOCK` 契约测试通过（不调用 epoll_wait）
- 120s 疲劳测试：6/6 模块线性增长，无冻结
